### PR TITLE
Plugin bridge: use 'create()' instead of 'gav()'

### DIFF
--- a/samples/use-all-java-module-plugins/build-logic/src/main/kotlin/org.my.gradle.java-module.gradle.kts
+++ b/samples/use-all-java-module-plugins/build-logic/src/main/kotlin/org.my.gradle.java-module.gradle.kts
@@ -17,7 +17,6 @@ javaModuleTesting.whitebox(
 
 testing.suites.create<JvmTestSuite>("integtest") {
     useJUnitJupiter("")
-    testType.set("blackbox")
     dependencies {
         implementation(project.dependencies.platform(project(":platform")))
     }

--- a/samples/use-only-java-module-testing-plugin/build-logic/src/main/kotlin/org.my.gradle.java-module.gradle.kts
+++ b/samples/use-only-java-module-testing-plugin/build-logic/src/main/kotlin/org.my.gradle.java-module.gradle.kts
@@ -17,7 +17,6 @@ javaModuleTesting.whitebox(
 
 testing.suites.create<JvmTestSuite>("integtest") {
     useJUnitJupiter("")
-    testType.set("blackbox")
     dependencies {
         implementation(project.dependencies.platform(project(":platform")))
     }

--- a/samples/use-with-test-fixtures/build-logic/build.gradle.kts
+++ b/samples/use-with-test-fixtures/build-logic/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation("org.gradlex:java-module-testing:1.5")
+    implementation("org.gradlex:java-module-dependencies:1.8")
 }

--- a/samples/use-with-test-fixtures/build-logic/src/main/kotlin/org.my.gradle.java-module.gradle.kts
+++ b/samples/use-with-test-fixtures/build-logic/src/main/kotlin/org.my.gradle.java-module.gradle.kts
@@ -2,12 +2,12 @@ plugins {
     id("java")
     id("java-test-fixtures")
     id("org.my.gradle.base")
+    id("org.gradlex.java-module-dependencies")
     id("org.gradlex.java-module-testing")
 }
 
 javaModuleTesting.whitebox(
     testing.suites.getByName<JvmTestSuite>("test") {
-        useJUnitJupiter()
         targets.all { testTask { testLogging.showStandardStreams = true } }
     }
 ) {
@@ -16,8 +16,6 @@ javaModuleTesting.whitebox(
 }
 
 testing.suites.create<JvmTestSuite>("integtest") {
-    useJUnitJupiter()
-    testType.set(TestSuiteType.INTEGRATION_TEST)
     targets.all { testTask { testLogging.showStandardStreams = true } }
     tasks.check { dependsOn(targets) }
 }

--- a/src/main/java/org/gradlex/javamodule/testing/JavaModuleTestingExtension.java
+++ b/src/main/java/org/gradlex/javamodule/testing/JavaModuleTestingExtension.java
@@ -256,18 +256,18 @@ public abstract class JavaModuleTestingExtension {
         Configuration implementation = configurations.getByName(testSources.getImplementationConfigurationName());
         implementation.withDependencies(d -> {
             for (String requiresModuleName : whiteboxJvmTestSuite.getRequires().get()) {
-                Provider<?> gav = JavaModuleDependenciesBridge.gav(project, requiresModuleName);
-                if (gav != null) {
-                    dependencies.addProvider(implementation.getName(), gav);
+                Provider<?> dependency = JavaModuleDependenciesBridge.create(project, requiresModuleName, whiteboxJvmTestSuite.getSourcesUnderTest().get());
+                if (dependency != null) {
+                    dependencies.addProvider(implementation.getName(), dependency);
                 }
             }
         });
         Configuration runtimeOnly = configurations.getByName(testSources.getRuntimeOnlyConfigurationName());
         runtimeOnly.withDependencies(d -> {
             for (String requiresModuleName : whiteboxJvmTestSuite.getRequiresRuntime().get()) {
-                Provider<?> gav = JavaModuleDependenciesBridge.gav(project, requiresModuleName);
-                if (gav != null) {
-                    dependencies.addProvider(runtimeOnly.getName(), gav);
+                Provider<?> dependency = JavaModuleDependenciesBridge.create(project, requiresModuleName, whiteboxJvmTestSuite.getSourcesUnderTest().get());
+                if (dependency != null) {
+                    dependencies.addProvider(runtimeOnly.getName(), dependency);
                 }
             }
         });

--- a/src/main/java/org/gradlex/javamodule/testing/internal/bridges/JavaModuleDependenciesBridge.java
+++ b/src/main/java/org/gradlex/javamodule/testing/internal/bridges/JavaModuleDependenciesBridge.java
@@ -17,10 +17,8 @@
 package org.gradlex.javamodule.testing.internal.bridges;
 
 import org.gradle.api.Project;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.compile.JavaCompile;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -28,14 +26,14 @@ import java.util.List;
 
 public class JavaModuleDependenciesBridge {
 
-    public static Provider<?> gav(Project project, String moduleName) {
+    public static Provider<?> create(Project project, String moduleName, SourceSet sourceSetWithModuleInfo)   {
         Object javaModuleDependencies = project.getExtensions().findByName("javaModuleDependencies");
         if (javaModuleDependencies == null) {
             return null;
         }
         try {
-            Method gav = javaModuleDependencies.getClass().getMethod("gav", String.class);
-            return (Provider<?>) gav.invoke(javaModuleDependencies, moduleName);
+            Method gav = javaModuleDependencies.getClass().getMethod("create", String.class, SourceSet.class);
+            return (Provider<?>) gav.invoke(javaModuleDependencies, moduleName, sourceSetWithModuleInfo);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/groovy/org/gradlex/javamodule/testing/test/JavaModuleDependenciesBridgeTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/testing/test/JavaModuleDependenciesBridgeTest.groovy
@@ -104,4 +104,32 @@ class JavaModuleDependenciesBridgeTest extends Specification {
         then:
         result.task(":app:compileTestJava").outcome == TaskOutcome.SUCCESS
     }
+
+    def "can be combined with test-fixtures plugins"() {
+        given:
+        useTestFixturesPlugin()
+        appModuleInfoFile << '''
+            module org.example.app { 
+            }
+        '''
+        file("app/src/testFixtures/java/module-info.java") << '''
+            open module org.example.app.test.fixtures {
+                requires org.example.app;
+            }
+        '''
+        appBuildFile << '''
+            javaModuleTesting.whitebox(testing.suites["test"]) {
+                requires.add("org.junit.jupiter.api")
+                requires.add("org.example.app.test.fixtures")
+            }
+            javaModuleDependencies {
+            }
+        '''
+
+        when:
+        def result = runTests()
+
+        then:
+        result.task(":app:test").outcome == TaskOutcome.SUCCESS
+    }
 }

--- a/src/test/groovy/org/gradlex/javamodule/testing/test/fixture/GradleBuild.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/testing/test/fixture/GradleBuild.groovy
@@ -100,6 +100,11 @@ class GradleBuild {
         libBuildFile.text = libBuildFile.text.replace('plugins {', 'plugins { id("org.gradlex.java-module-dependencies")')
     }
 
+    def useTestFixturesPlugin() {
+        appBuildFile.text = appBuildFile.text.replace('plugins {', 'plugins { id("java-test-fixtures");')
+        libBuildFile.text = libBuildFile.text.replace('plugins {', 'plugins { id("java-test-fixtures");')
+    }
+
     File file(String path) {
         new File(projectDir, path).tap {
             it.getParentFile().mkdirs()


### PR DESCRIPTION
This updates the bridge to the java-module-dependencies plugin to delegate the complete dependency creation to that plugin. With this, also dependencies to local projects and features are created.

Fixes #85